### PR TITLE
Implement Httptest to cache test and vignette responses

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -100,7 +100,7 @@ jobs:
       - name: Install dependencies macOS and Linux
         if: runner.os != 'Windows'
         run: |
-          remotes::install_deps(dependencies = TRUE)
+          remotes::install_deps(dependencies = TRUE, type = "both")
           remotes::install_cran("rcmdcheck")
           remotes::install_cran("codecov")
         shell: Rscript {0}
@@ -108,7 +108,7 @@ jobs:
       - name: Install dependencies Windows
         if: runner.os == 'Windows'
         run: |
-          remotes::install_deps(dependencies = TRUE, type = "binary")
+          remotes::install_deps(dependencies = TRUE, type = "both")
           remotes::install_cran("rcmdcheck")
           remotes::install_cran("codecov")
         shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -141,4 +141,3 @@ jobs:
       - name: Test coverage
         run: covr::codecov()
         shell: Rscript {0}
-

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,21 +20,18 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'devel', continue-on-error: true }
-          - {os: macOS-latest,   r: 'release', continue-on-error: true }
-          - {os: windows-latest, r: 'release', continue-on-error: false }
-          - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest", continue-on-error: false }
-          - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest", continue-on-error: true }
-          - {os: ubuntu-16.04,   r: '3.6',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest", continue-on-error: true }
-
+          - {os: macOS-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release', continue-on-error: true }
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     continue-on-error: ${{ matrix.config.continue-on-error }}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      CI: true
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
       - uses: actions/checkout@v2
@@ -42,6 +39,8 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,11 +39,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Brew and macOS config
         if: runner.os == 'macOS'

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 attic/*
 docs/*
 inst/doc
+!attic/layer_sizes.csv
+!attic/query_layer_sizes.R
+tests/testthat/*/*
+vignettes/*/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ inst/doc
 !attic/query_layer_sizes.R
 tests/testthat/*/*
 vignettes/*/*
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,15 +29,16 @@ Encoding: UTF-8
 LazyData: true
 Depends: R (>= 3.6.0)
 Suggests: 
-    testthat (>= 2.1.0),
     covr,
-    knitr,
-    rmarkdown,
     dplyr,
+    httptest,
+    knitr,
     mapview,
-    testthis,
-    skimr
-RoxygenNote: 7.1.1
+    rmarkdown,
+    skimr,
+    testthat (>= 2.1.0),
+    testthis
+RoxygenNote: 7.1.2
 SystemRequirements: C++11, GDAL (>= 2.0.1), GEOS (>= 3.4.0),
     PROJ (>= 4.8.0)
 Imports: 

--- a/attic/layer_sizes.csv
+++ b/attic/layer_sizes.csv
@@ -1,0 +1,1420 @@
+service_name,service_url,layer_namespace,layer_name,layer_size_bytes,error,timeout_secs
+bathymetry,https://ows.emodnet-bathymetry.eu/wfs,emodnet,contours,NA,Timeout was reached: [ows.emodnet-bathymetry.eu] Operation timed out after 5002 milliseconds with 0 bytes received,5
+bathymetry,https://ows.emodnet-bathymetry.eu/wfs,emodnet,quality_index,NA,Timeout was reached: [ows.emodnet-bathymetry.eu] Operation timed out after 5004 milliseconds with 0 bytes received,5
+bathymetry,https://ows.emodnet-bathymetry.eu/wfs,emodnet,source_references,NA,Timeout was reached: [ows.emodnet-bathymetry.eu] Operation timed out after 5005 milliseconds with 0 bytes received,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_cor_abs_pnt,826344,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_cor_abs_poly,5806784,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_cymodocea_pnt,755344,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,Species_gridded_abundances_10year,12360760,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,Species_gridded_abundances_2year,2143072,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,Species_gridded_abundances_3year,886928,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,Species_gridded_abundance_all,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5002 milliseconds with 540672 bytes received,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_halophila_pnt,61672,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_maerl_pnt,87176,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_maerl_poly,261032,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_posidonia_model,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5003 milliseconds with 1253376 bytes received,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_coral_model,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5000 milliseconds with 1169618 bytes received,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_maerl_model,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5003 milliseconds with 1417216 bytes received,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,OOPS_errors,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5001 milliseconds with 401408 bytes received,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,OOPS_metadata,2832928,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,OOPS_products,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5001 milliseconds with 211434 bytes received,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,OOPS_products_vliz,10862232,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,OOPS_regions,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5000 milliseconds with 2725578 bytes received,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,OOPS_summaries,29464312,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_cor_pnt,389496,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_cor_poly,3990080,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_posidonia_abs,745528,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_posidonia_nodata,1797944,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_posidonia_current_pnt,375368,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_posidonia_current_shape,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5000 milliseconds with 239802 bytes received,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_posidonia_historical_shape,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5000 milliseconds with 0 bytes received,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_posidonia_historical_pnt,36600,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_ruppia_c_pnt,24000,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_ruppia_m_pnt,18208,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_zostera_m_pnt,44672,NA,5
+biology,http://geo.vliz.be/geoserver/Emodnetbio/wfs,Emodnetbio,mediseh_zostera_n_pnt,73224,NA,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,abiotic_observations,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5005 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,biotic_observations,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5000 milliseconds with 112330 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,eurobis-obisenv_basic,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5004 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,eurobis-obisenv_count,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5000 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,eurobis-obisenv_full,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5002 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,eurobis-obisenv,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5005 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,eurobis_grid_15m-obisenv,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5005 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,eurobis_grid_1d-obisenv,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5005 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,eurobis_grid_30m-obisenv,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5000 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,eurobis_grid_6m-obisenv,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5005 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,eurobis_points-obisenv,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5003 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,iucn_grid,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5000 milliseconds with 491914 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,abiotic_observations_count,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5002 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,biotic_observations_count,13008,NA,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,categories,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5000 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,categories_get_by_datatype,22384,NA,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,datafiches_get_by_datasource_and_dataorigin_and_datatype,12872,NA,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,dataorigin_get_by_datasource_and_datatype,12824,NA,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,dataportal_get_observations_where,12776,NA,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,dataproviders_get_by_datatype,12784,NA,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,datasets,22568,NA,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,eurobis,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5005 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,geoobjects,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5000 milliseconds with 3948544 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,geoobjects_get_by_name,16056,NA,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,parameters,NA,Timeout was reached: [geo.vliz.be] Operation timed out after 5003 milliseconds with 0 bytes received,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,parameters_get_by_name_and_category,702984,NA,5
+biology_occurrence_data,http://geo.vliz.be/geoserver/Dataportal/wfs,Dataportal,taxa,593936,NA,5
+chemistry_cdi_data_discovery_and_access_service,https://geo-service.maris.nl/emodnet_chemistry/wfs,emodnet_chemistry,points,NA,Timeout was reached: [geo-service.maris.nl] Operation timed out after 5002 milliseconds with 0 bytes received,5
+chemistry_cdi_data_discovery_and_access_service,https://geo-service.maris.nl/emodnet_chemistry/wfs,emodnet_chemistry,polygons,102704,NA,5
+chemistry_cdi_data_discovery_and_access_service,https://geo-service.maris.nl/emodnet_chemistry/wfs,emodnet_chemistry,tracks,NA,Timeout was reached: [geo-service.maris.nl] Operation timed out after 5002 milliseconds with 0 bytes received,5
+chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs,emodnet_chemistry_p36,acidity,NA,Timeout was reached: [geo-service.maris.nl] Operation timed out after 5004 milliseconds with 0 bytes received,5
+chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs,emodnet_chemistry_p36,antifoulants,1391648,NA,5
+chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs,emodnet_chemistry_p36,chlorophyll,NA,Timeout was reached: [geo-service.maris.nl] Operation timed out after 5002 milliseconds with 0 bytes received,5
+chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs,emodnet_chemistry_p36,dissolved_gasses,NA,Timeout was reached: [geo-service.maris.nl] Operation timed out after 5000 milliseconds with 0 bytes received,5
+chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs,emodnet_chemistry_p36,fertilisers,NA,Timeout was reached: [geo-service.maris.nl] Operation timed out after 5005 milliseconds with 0 bytes received,5
+chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs,emodnet_chemistry_p36,heavy_metals,NA,Timeout was reached: [geo-service.maris.nl] Operation timed out after 5002 milliseconds with 0 bytes received,5
+chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs,emodnet_chemistry_p36,hydrocarbons,NA,Timeout was reached: [geo-service.maris.nl] Operation timed out after 5002 milliseconds with 0 bytes received,5
+chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs,emodnet_chemistry_p36,marine_litter,NA,Timeout was reached: [geo-service.maris.nl] Operation timed out after 5005 milliseconds with 0 bytes received,5
+chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs,emodnet_chemistry_p36,organic_matter,NA,Timeout was reached: [geo-service.maris.nl] Operation timed out after 5000 milliseconds with 3651110 bytes received,5
+chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs,emodnet_chemistry_p36,pesticides_biocides,NA,Timeout was reached: [geo-service.maris.nl] Operation timed out after 5000 milliseconds with 9028660 bytes received,5
+chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs,emodnet_chemistry_p36,polychlorinated_biphenyls,5833792,NA,5
+chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs,emodnet_chemistry_p36,radionuclides,2032104,NA,5
+chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs,emodnet_chemistry_p36,silicates,NA,Timeout was reached: [geo-service.maris.nl] Operation timed out after 5002 milliseconds with 0 bytes received,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Anthracene_biota_stations,1635104,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Anthracene_sediment_stations,4972008,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Anthracene_a_LOD_LOQ_stations,5701144,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Anthracene_a_b_LOD_LOQ_stations,707992,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Anthracene_b_LOD_LOQ_stations,376248,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Anthracene_water_stations,444744,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Benzo_a_pyrene_not_compliant_biota_metadata,127104,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Benzo_a_pyrene_biota_stations,1623904,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Benzo_a_pyrene_sediment_stations,4760712,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Benzo_a_pyrene_a_LOD_LOQ_stations,5673080,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Benzo_a_pyrene_a_b_LOD_LOQ_stations,759584,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Benzo_a_pyrene_b_LOD_LOQ_stations,374136,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Benzo_a_pyrene_water_stations,700920,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Cd_biota_stations,2545016,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Cd_sediment_stations,7025616,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Cadmium_a_LOD_LOQ_stations,9423344,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Cadmium_a_b_LOD_LOQ_stations,646608,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Cadmium_b_LOD_LOQ_stations,2050120,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Cd_water_stations,2411592,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,DDT_biota_stations,2599696,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,DDT_sediment_stations,3320480,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,DDT_a_LOD_LOQ_stations,4257272,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,DDT_a_b_LOD_LOQ_stations,1382280,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,DDT_b_LOD_LOQ_stations,1407152,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,DDT_water_stations,1513360,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,fluoranthene_LOQ_not_compliant_biota_metadata,60856,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,fluoranthene_LOQ_not_compliant_water_metadata,72832,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Fluoranthene_biota_stations,2090744,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Fluoranthene_sediment_stations,5092296,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Fluoranthene_a_LOD_LOQ_stations,6428320,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Fluoranthene_a_b_LOD_LOQ_stations,419424,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Fluoranthene_b_LOD_LOQ_stations,186536,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Fluoranthene_water_stations,447456,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,HCB_LOQ_not_compliant_biota_metadata0,90504,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,HCB_biota_stations0,1056128,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,HCB_sediment_stations0,3348224,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,HCB_a_LOD_LOQ_stations0,7588616,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,HCB_a_b_LOD_LOQ_stations0,700912,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,HCB_b_LOD_LOQ_stations0,1552248,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,HCB_water_stations0,670216,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Lead_biota_stations0,2595808,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Lead_sediment_stations0,9015680,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Lead_a_LOD_LOQ_stations0,13249416,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Lead_a_b_LOD_LOQ_stations0,260680,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Lead_b_LOD_LOQ_stations0,636432,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Lead_water_stations0,2398896,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Mercury_biota_stations0,3737224,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Mercury_sediment_stations0,7512288,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Mercury_a_LOD_LOQ_stations0,11193520,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Mercury_a_b_LOD_LOQ_stations0,820240,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Mercury_b_LOD_LOQ_stations,848000,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Mercury_water_stations0,2632456,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Naphthalene_biota_stations0,699896,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Naphthalene_sediment_stations0,4063832,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Naphthalene_a_LOD_LOQ_stations0,4383696,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Naphthalene_a_b_LOD_LOQ_stations0,532184,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Naphthalene_b_LOD_LOQ_stations0,297928,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Naphthalene_water_stations0,331224,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Tributyltin_biota_stations0,565608,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Tributyltin_sediment_stations0,1443880,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Tributyltin_a_LOD_LOQ_stations0,1853808,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Tributyltin_a_b_LOD_LOQ_stations0,137640,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Tributyltin_b_LOD_LOQ_stations0,246456,NA,5
+chemistry_contaminants,https://nodc.ogs.trieste.it/geoserver/Contaminants/wfs,Contaminants,Tributyltin_water_stations0,41800,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_beacheslocations_monitoring,13936,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_temporalcoverage_numbersurveys_monitoring,13968,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_totalabundance_monitoring,13936,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_materialcategories_monitoring,13936,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_cigarette_monitoring,13920,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_cigarette_unep_marlin_monitoring,13936,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_fishing_monitoring,13920,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_plasticbags_monitoring,13920,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_beacheslocations_other,13920,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_temporalcoverage_numbersurveys_other,13952,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_totalabundance_other,13920,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_materialcategories_other,13920,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_cigarette_other,13920,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_cigarette_unep_marlin_other,13936,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_fishing_other,13920,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,bl_plasticbags_other,13920,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,sl_surveyslocations,13920,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,sl_totalabundance,13920,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,sl_materialcategories,13920,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,sl_fishing,13920,NA,5
+chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2,ms,sl_plasticbags,13920,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_fd_000_0_80k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 0 bytes received,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_fd_1_1250k_3m,2704232,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_fd_01_250k_350k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 891846 bytes received,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_fd_015_350k_450k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5002 milliseconds with 1096254 bytes received,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_fd_2_3m_90m,1128592,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_fd_02_450k_650k,17600568,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_fd_005_50k_250k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5002 milliseconds with 0 bytes received,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_fd_05_650k_1250k,6308896,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_fd_0025_80k_150k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5005 milliseconds with 0 bytes received,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_satellite_0_40k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 0 bytes received,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_satellite_1250k_3m,3144176,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_satellite_150k_250k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 917504 bytes received,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_satellite_250k_350k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 964542 bytes received,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_satellite_350k_450k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5003 milliseconds with 1810432 bytes received,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_satellite_3m_100m,1205496,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_satellite_40k_80k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5007 milliseconds with 0 bytes received,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_satellite_450k_650k,7969208,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_satellite_650k_1250k,8033160,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_migration_satellite_80k_150k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 538974 bytes received,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_type_20210501_0_80k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5008 milliseconds with 0 bytes received,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_type_20210501_1_1250k_3m,3313232,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_type_20210501_005_150k_250k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5006 milliseconds with 1794048 bytes received,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_type_20210501_01_250k_350k,27543984,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_type_20210501_015_350k_450k,22487008,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_type_20210501_2_3m_90m,1336888,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_type_20210501_02_450k_650k,18553640,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_type_20210501_05_650k_1250k,7400416,NA,5
+geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs,tno,coastal_type_20210501_0025_80k_150k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5007 milliseconds with 1251558 bytes received,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,geological_event_distribution_100k,2355760,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,geological_event_distribution_250k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5005 milliseconds with 2293760 bytes received,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,tectonics_lin_100k,10786952,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,quaternary_tectonics_lin_250k,6048168,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,earthquakes_pt_100k,5049032,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,mud_volc_fluid_emis_pt_100k,545832,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,mud_volc_fluid_emis_pt_250k,492672,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,mud_volc_fluid_emis_pol_100k,5940352,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,mud_volc_fluid_emis_pol_250k,928064,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,landslide_pt_100k,61296,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,landslide_pt_250k,137432,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,landslide_pol_100k,3342144,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,landslide_pol_250k,4185672,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,landslide_lin_100k,623624,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,landslide_lin_250k,1248984,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,volcanic_center_lin_100k,701240,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,volcanic_center_lin_250k,237128,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,volcanic_center_pt_100k,724824,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,volcanic_center_pt_250k,340528,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,volcanic_center_pol_100k,3679064,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,volcanic_center_pol_250k,2783488,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,tsunami_pt2,144456,NA,5
+geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs,ispra,tsunami_pt,195640,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,MarineAggregatesArea,13696,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,MarineAggregatesPoint,9177344,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,CobaltRichFerromanganeseCrustsArea,1509328,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,CobaltRichFerromanganeseCrustsPoint,129288,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,EvaporitesArea,624392,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,EvaporitesPoint,296880,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,GasHydratesArea,38032,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,GasHydratesPoint,48928,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,MarineHydrocarbonsArea,7340416,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,MarineHydrocarbonsPoint,2252008,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,MarinePlacerDepositsArea,156640,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,MarinePlacerDepositsPoint,85432,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,MarineSapropelArea,34616,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,MarineSapropelPoint,15152,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,MetalRichSedimentsArea,66736,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,MetalRichSedimentsPoint,40888,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,PhosphoritesArea,708216,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,PhosphoritesPoint,45944,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,PolymetallicNodulesArea,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5007 milliseconds with 147102 bytes received,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,PolymetallicNodulesPoint,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5005 milliseconds with 0 bytes received,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,PolymetallicSulphidesPoint,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 0 bytes received,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,RockPegVeinArea,115112,NA,5
+geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs,gsi,RockPegVeinPoint,43304,NA,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,geomorphology,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 2573206 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,pre_quaternary_poly,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5006 milliseconds with 2007040 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,pre_quaternary_faults,28069072,NA,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,quaternary_poly,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5004 milliseconds with 0 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,general_physiographic_features,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5002 milliseconds with 0 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,geomorphology_feature_boundaries,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 0 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,geomorphology_preliminary_features,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 1515520 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,pre_quaternary_age_2021,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 2072576 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,pre_quaternary_faults_2021,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 1081344 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,pre_quaternary_lithology_2021,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5002 milliseconds with 2503070 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,quaternary_age_gt100k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5002 milliseconds with 0 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,quaternary_age_lt1000k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 376832 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,quaternary_age_lt100k_gt300k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5003 milliseconds with 655360 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,quaternary_age_lt300k_gt1000k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5003 milliseconds with 0 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,quaternary_lithology_gt100k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5002 milliseconds with 0 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,quaternary_lithology_lt1000k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5003 milliseconds with 1652958 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,quaternary_lithology_lt100k_gt300k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 2883006 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,quaternary_lithology_lt300k_gt1000k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 309518 bytes received,5
+geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs,bgr,sea_floor_geomorphology,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 2635246 bytes received,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_100k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5001 milliseconds with 0 bytes received,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_1m,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 1844014 bytes received,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_250k,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5004 milliseconds with 0 bytes received,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,sedimentation_rates,1497520,NA,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_10k_multiscale,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5001 milliseconds with 0 bytes received,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_15k_multiscale,9264864,NA,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_1k5_multiscale,107720,NA,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_20k_multiscale,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5001 milliseconds with 0 bytes received,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_25k_multiscale,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5005 milliseconds with 0 bytes received,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_30k_multiscale,210384,NA,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_45k_multiscale,350552,NA,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_50k_multiscale,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5005 milliseconds with 0 bytes received,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_5k_multiscale,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 2707174 bytes received,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_60k_multiscale,251360,NA,5
+geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs,gtk,seabed_substrate_70k_multiscale,355080,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,ArchaeologicalPoint,70696,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,ArchaeologicalGeomorphologicalPL,27408,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,ChannelPL,2869584,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,ChannelPG,3786576,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandformPL,672376,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandformPG,6935400,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,Coastal_Submarine-SpringsPoint,130832,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-DeltaPL,20680,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-DeltaPG,1184720,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-EstuaryPL,15760,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-EstuaryPG,761880,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-KarstPoints,220496,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-KarstPG,26016,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,LastGlacialMaximumPL,12152768,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-LagoonPG,587376,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-LakePG,1501096,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-PAlluvialPG,53544,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,Coastline-PalaeocoastlinePL,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5000 milliseconds with 3153920 bytes received,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,Sealevel-IndexPoints,789544,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-SubaerialLandslidePL,13648,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-SubaerialLandslidePoints,13672,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-SubaerialLandslidePG,1035448,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-SubmergedForestPoints,139784,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-SubmergedForestPG,33344,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,SubmergedPeatPoint,527552,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-TerracePL,779984,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-TerracePG,1796912,NA,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,LastGlacialMaximum-ThicknessPL,NA,Timeout was reached: [drive.emodnet-geology.eu] Operation timed out after 5002 milliseconds with 3182982 bytes received,5
+geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs,bgs,CoastalLandform-WetlandsPG,857328,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,activelicenses,5966328,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,aquaculture,31165480,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,baltic,871760,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,blacksea,77048,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,longdistancefleet,19309120,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,market,34535064,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,mediterranean,617208,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,northsea,513696,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,northwesternwaters,418048,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,outermostregions,5316256,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,pelagicstocks,1330184,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,southwesternwaters,142872,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,aggregates,5865376,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,aggregateareas,2476136,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,barcelona,13944768,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,hydrocarbons,19329248,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,bucharest,3708456,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,dischargepoints,47172832,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,dredgespoil,1063264,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,dredgespoilpoly,4321160,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,dredging,15268856,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,munitions,199632,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,munitionspoly,819632,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,eeacoastline,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 11449779 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,eez,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 10854400 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,finfish,7078536,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,fishsales,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 5008326 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,divisioncatches,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5002 milliseconds with 8167352 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,majorcatches,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 7120051 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,subareacatches,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 10399089 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,subdivisioncatches,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 10821632 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,subunitcatches,3490824,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,divisioneffort,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 11722752 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,gfcmsubareaeffort,26679288,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,majoreffort,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 7790592 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,subareaeffort,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 10895882 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,subdivisioneffort,38127368,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,subuniteffort,118480,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,freshwater,23016584,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,helcom,14076304,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,icesareas,51519856,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,lighthouses,2885472,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,reportingunits,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 10313728 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,mspspatialplan,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 11402913 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,mspzoningpoly,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 10906882 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,mspzoningline,1677104,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,mspzoninglocs,893144,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,macroalgae,459472,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,portgoods,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5002 milliseconds with 2643150 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,portlocations,361192,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,portpassengers,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5001 milliseconds with 2528569 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,portvessels,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 3788908 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,maritimebnds,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 10568011 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,microalgae,169392,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,militaryareas,38376,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,militaryareaspoly,518936,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,cddaareas,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 11602462 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,natura2000areas,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 11395072 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,nuclear,202184,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,ospar,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 10846402 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,oenergy,534448,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,oenergytests,130248,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,platforms,2193120,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,pipelines,27004024,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,pcablesshom,342920,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,pcablesrijks,6970840,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,pcablesnve,5952808,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,shellfish,2783504,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,shipwrecksshom,4140272,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,spirulina,246088,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,bathingwaters,NA,Timeout was reached: [ows.emodnet-humanactivities.eu] Operation timed out after 5000 milliseconds with 3273314 bytes received,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,cablesschematic,277720,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,bshcontiscables,329040,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,cicacables,37824,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,shomcables,978312,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,sigcables,125544,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,landingstations,176368,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,maltacables,21488,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,rijkscables,340048,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,ukfibrecables,50648,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,treatmentplants,67143832,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,wasteatports,32328,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,wasteatports_m3,200552,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,wasteatports_tonnes,41272,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,windfarms,168680,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,windfarmspoly,885824,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,desalination,25123720,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,fishingbeamtrawls,14310568,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,fishingbottomottertrawls,35831360,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,fishingbottomseines,13595864,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,fishingdredges,4240472,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,fishingpelagic,30021184,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,fishingstaticgears,16243840,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,fishingsubsurface,37727496,NA,5
+human_activities,https://ows.emodnet-humanactivities.eu/wfs,emodnet,fishingsurface,37201584,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_PSM_SLEV_TG_TS_ANO,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5002 milliseconds with 0 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_SLEV_TG_TS_ABS,124320,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_SON_SLEV_GR_TS_TRE,3747680,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_PSM_SLEV_TG_TS_TRE,201680,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_TEMP_AR_PP_GLO,6722384,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_DB_PP_GLO,4051408,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_FB_PP_GLO,37248,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_PSM_SLEV_FS_PP_NNN,573432,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_GRD_RVFL_FS_PP_GLO,15070384,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_WIND_GL_PP_GLO,40880,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_HF_PP_GLO,14768,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_MO_PP_GLO,1530976,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_AL_PP_GLO,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5000 milliseconds with 1537234 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_RVFL_FS_PP_GLO,77744,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_TG_PP_GLO,745256,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ATMS_AL_PP_GLO,4831328,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_BGCP_AL_PP_GLO,24115056,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_LHAT_AL_PP_GLO,15856968,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_OPTS_AL_PP_GLO,15843128,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_AP_PP_GLO,6722384,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_HCXX_AL_PP_GLO,33580376,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_SLEV_AL_PP_GLO,1177920,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_TEMP_AL_PP_GLO,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5001 milliseconds with 2409378 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_UWNO_AL_PP_GLO,16984,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_WAVE_AL_PP_GLO,612224,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_WIND_AL_PP_GLO,503368,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_AL_PP_ARC,17923720,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_AL_PP_ATL,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5000 milliseconds with 1806970 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_AL_PP_BAL,15606896,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_AL_PP_BLS,101368,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_AL_PP_MED,847368,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_AL_PP_NWS,3360376,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_ALLP_AL_PP_JS3,267848,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_PSM_SLEV_TG_PP_GLO,2002304,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_TEMP_OT_PP_GLO,13304,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_UWNO_XX_GR_INR,2848568,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_UWNO_XX_PD_INR,2848568,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_UWNO_XX_VC_INR,2848568,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_WIND_MO_TS_NRT,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5001 milliseconds with 323418 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_INT_RVFL_RS_TS_VAR,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5002 milliseconds with 0 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_SONEL_SLEV_ABS,121800,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,Sonel_GPS_TG,532896,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PSMSL_STATIONS_DB,1974480,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_AR,6596496,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_DB,3972360,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_FB,36784,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_HR,34576,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_HFR,14720,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,JN_PLATFORMS,261112,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_GL,40360,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_MO,1502504,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5000 milliseconds with 2759042 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_BGCP,23719672,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_LHAT,15594440,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_OPTS,15594440,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_SLEV,1222128,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_TEMP,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5001 milliseconds with 2751050 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_WIND,496216,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_WAVE,602984,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_ATMS,4756296,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_WX,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5000 milliseconds with 2336450 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_HCXX,33029216,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_ARC_PLATFORMS,17624424,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_ATL_PLATFORMS,82880312,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_BAL_PLATFORMS,15337120,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_BLS_PLATFORMS,99832,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_MED_PLATFORMS,832376,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_NWS_PLATFORMS,3301256,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_OTH_PLATFORMS,13280,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_AP,6590640,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_RVFL,76616,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_UWN_INER,2608232,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PSMSL_SLA,74712,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PSMSL_SLEV_REL,197400,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PSMSL_SLEV_REL_REGION,3736488,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_UWN_INER_Pulse_days,2797072,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_UWN_INER_Value_Codes,2814240,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_RIVER_RVFL,191568,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_NRT_WIND_WDIR_WSPD,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5001 milliseconds with 540672 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_PLATFORMS_UWNO,16912,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,PSMSL_Region,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5000 milliseconds with 9052890 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_WSEA_OTHR_NN_GR_EUR,6394352,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,World_Seas_RF,6391992,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,EP_GEO_WSEA_OTHR_NN_GR_GLO,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5001 milliseconds with 7543370 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,World_Seas,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5009 milliseconds with 7543370 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,World_Seas_Antarctic,3430800,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,psmslstationspace,544824,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_ap_psal_60d_3031,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5003 milliseconds with 1420346 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_ap_psal_7d_3031,648456,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_ap_temp_60d_3031,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5006 milliseconds with 1537234 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_ap_temp_7d_3031,650040,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_db_psal_60d_3031,9254184,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_db_psal_7d_3031,590784,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_db_temp_60d_3031,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5000 milliseconds with 2148634 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_db_temp_7d_3031,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5000 milliseconds with 2157626 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_fb_psal_60d_3031,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5004 milliseconds with 2121666 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_fb_psal_7d_3031,20813352,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_fb_temp_60d_3031,NA,Timeout was reached: [geoserver.emodnet-physics.eu] Operation timed out after 5005 milliseconds with 2202586 bytes received,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_fb_temp_7d_3031,23571128,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_gl_psal_60d_3031,6548888,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_gl_psal_7d_3031,698560,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_gl_temp_60d_3031,7070176,NA,5
+physics,https://geoserver.emodnet-physics.eu/geoserver/emodnet/wfs,emodnet,route_gl_temp_7d_3031,713960,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,art17_hab_1150,370856,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,art17_hab_1130,293616,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,art17_hab_1160,343840,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,art17_hab_1140,381128,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,art17_hab_1120,136064,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,art17_hab_1170,659496,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,art17_hab_1110,362104,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,art17_hab_1180,28176,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,biogenic_substrate_2021,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 4165656 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,habitat_point_eunis,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5009 milliseconds with 0 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,habitat_point,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5007 milliseconds with 0 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,gems_annexi_full,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5003 milliseconds with 0 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,coralligenous_platforms_2021,1341352,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,eusm2019_bio_full,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5005 milliseconds with 0 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,eusm2019_ene_full,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5010 milliseconds with 0 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,eusm2019_subs_full,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5008 milliseconds with 0 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,eusm2021_bio_full,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5004 milliseconds with 0 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,eusm2021_ene_full,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5007 milliseconds with 0 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,eusm2021_subs_full,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5003 milliseconds with 0 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,eusm2019_regions,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5006 milliseconds with 0 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,eov_2021_points_hard_coral,6233176,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,eov_livecoral,4799456,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,eov_2021_points_Macroalgal_canopy_cover,27386536,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,eov_macroalgae,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 564696 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,eov_2021_points_Seagrass_cover,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5007 milliseconds with 188232 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,eov_seagrass,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5007 milliseconds with 0 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,habitat_point_bboxes,5673528,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,ospar2020_points,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 900240 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,ospar2020_poly,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5008 milliseconds with 0 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,ospar_points,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5002 milliseconds with 908424 bytes received,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,ospar_overview,550552,NA,5
+seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs,emodnet_open,ospar_poly,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5009 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000225,51088,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000226,28576,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000227,34480,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000228,119872,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004015,90336,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001308,309352,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001517,54536,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100299,1159264,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100355,579688,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100361,111176,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100397,250672,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100398,244752,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100399,101224,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100440,637784,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,nl000066,338672,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,nl000065,2407152,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie004001,3238136,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000007,106808,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000017,105688,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000031,137816,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000048,36224,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000051,27056,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000054,32544,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000057,100472,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000060,49680,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000065,46872,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000071,36608,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000142,62176,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000143,79600,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000144,237712,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000145,239288,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000222,127168,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000223,137584,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000224,185576,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000229,68752,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000230,49328,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,be000231,36528,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,bg003002,139840,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,bg003003,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5003 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,bg003004,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 5786088 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,bg003005,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 5867928 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,bg004001,2947112,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,bg004002,1104488,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,bg004003,129848,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,de004001,4681864,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,de004002,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 5581488 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003001,115712,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003002,29744,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003003,27360,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003004,43984,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003005,31264,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003006,37040,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003007,27728,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003008,24496,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003009,18984,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003010,21416,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003011,105864,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003012,59264,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003013,51248,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003014,73320,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003015,22856,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003016,62192,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003017,37488,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003018,48400,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003019,17424,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003020,84048,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003021,24064,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003022,20760,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003023,21648,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003024,19352,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003025,220480,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003026,47896,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003027,20280,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003028,38056,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003029,34096,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003030,86048,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003031,19808,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003032,23832,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003033,24488,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003034,78528,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003035,83208,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003036,53232,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003037,39144,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003038,24240,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003039,57640,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003040,48592,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003041,30536,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003042,16008,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003043,59136,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003044,100344,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003045,19008,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003046,54016,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003047,111064,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003048,41296,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003049,22240,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003050,25920,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003051,43552,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003052,47904,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003053,71816,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003054,35048,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003055,30952,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003056,26768,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003057,48600,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003058,29488,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003059,24680,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003060,44464,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003061,123600,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003062,66912,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003063,16064,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003064,399560,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003065,124728,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003066,84304,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003067,24912,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003068,66392,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003069,221032,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003070,126688,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003071,220976,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003072,252552,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003073,99040,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003074,88216,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003075,28352,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003076,80264,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk003077,17616,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk004001,188248,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk004002,34816,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk004003,36864,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk004004,25976,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,dk004005,121240,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,es000001,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 2226048 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,es001000,159064,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,es001001,274360,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,es001002,396696,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,es001021,4868808,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,es001022,3303376,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,es001023,3466544,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,es001024,4929168,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,es001025,5616632,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,es001026,210552,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,es001027,3922736,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,es003011,10737664,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,es003012,20341560,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000003,758616,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000004,1445128,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000008,926848,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000025,23712672,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000035,7570440,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000036,17376512,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000037,12054784,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000040,200504,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000041,14728,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000043,6728720,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000046,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 7193736 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000048,716960,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000051,1186096,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000055,2295920,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000056,3939320,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000058,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 5638776 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000059,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5004 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr000060,13654256,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr002000,1435744,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr002001,4024616,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr002002,5567920,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003001,9421096,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003002,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5008 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003003,29348800,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003004,11347248,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003005,25528416,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003006,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 6792720 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003007,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 5892480 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003008,419392,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003009,5821888,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003010,1167456,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003011,551376,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003012,8089152,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003013,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5002 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003014,3835824,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003016,14900872,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003017,7501928,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003018,129320,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003019,25017536,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003020,50744,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003021,18444128,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003022,457000,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003023,30147928,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003025,2516456,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003027,24939800,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003028,3570224,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003029,838264,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003030,31159624,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003031,37616016,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003032,1216584,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003033,134640,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003034,14221488,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003035,112792,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003036,900120,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003037,5258904,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003038,358184,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003039,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5006 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003040,6625584,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003041,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 7733880 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003042,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 5671512 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003043,2429904,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003044,23118344,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003045,709576,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003046,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 2242416 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003047,250928,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003048,29316744,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003049,840936,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003050,22833040,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003051,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003052,13407640,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003053,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5008 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003054,10616864,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003055,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5007 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003056,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5002 milliseconds with 7111896 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003057,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5005 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003058,3124992,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003059,10800904,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003060,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 5777904 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003061,26287136,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003062,964848,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003063,7307616,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003064,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 4918584 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003065,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5009 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003066,1449432,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003067,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 5335968 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003068,2320456,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003069,118984,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003070,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003071,14531256,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003072,15690880,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003073,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 556512 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003074,11803552,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003075,2697600,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003076,33492328,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003077,7115912,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003078,2141168,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003079,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5001 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003080,13827032,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr003081,6268680,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004001,837776,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004002,401360,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004003,3158472,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004004,1220256,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004005,249920,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004006,1113640,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004008,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5005 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004009,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 5090448 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004010,3118296,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004011,8666504,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004012,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 7013688 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004016,386752,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004017,6230360,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004018,2389640,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004019,17004904,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004020,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5003 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004021,17912992,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004022,856304,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004023,3125472,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004024,2291264,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004025,871456,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004026,183448,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004027,233248,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004028,2783320,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004029,422632,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004030,3382408,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004031,14861336,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004032,35229392,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004033,1096560,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004034,14709136,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004035,1357704,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004036,4046056,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004037,1023336,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004038,4204768,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004039,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 7267392 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004040,481608,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004041,1540848,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004042,248280,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004043,689960,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,fr004044,18914056,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000039,425296,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000215,910776,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000217,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5002 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000223,13005848,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000225,3134616,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000226,1076800,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000227,2426960,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000228,93336,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000229,1486456,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000230,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 4836744 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000231,1024104,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000233,126184,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000234,836560,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000235,190568,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000236,1110296,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000239,6701992,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000240,4647248,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000243,6770872,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000244,71808,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000245,830632,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000247,592928,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000248,2311368,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000249,751472,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000253,7118080,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000258,10650568,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000259,1108088,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000263,3860104,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000267,1638480,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000268,1716928,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000272,5141832,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000273,2950680,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000277,840184,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000278,2660992,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000279,9382752,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000281,3132864,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000282,579704,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000283,5961816,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000284,5081096,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000285,7537672,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000286,1754992,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000287,2987856,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000288,24182496,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000289,5273880,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000290,13950712,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000291,1926152,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000292,7221224,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000293,1342896,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000294,13328624,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000295,35331976,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000296,15867368,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000297,20921608,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000298,15753056,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000299,3169624,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000300,2971008,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000301,12771128,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000302,3127752,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000303,1866624,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000304,4815976,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000305,1103392,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000306,16455488,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000307,760064,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000308,2080664,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000309,4221528,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000310,12154376,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000311,938704,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000312,882760,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000313,217104,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000314,262184,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000315,346000,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000319,888696,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000326,750376,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000329,7650584,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000333,29984,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000334,68136,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000335,447664,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000336,3042296,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000337,65456,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000356,1258568,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000357,2475000,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000358,1884736,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000359,276768,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000360,1707056,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000361,849016,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000363,1225920,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000364,975208,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000365,2458584,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000367,4235024,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000369,3917616,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000371,23203248,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000372,3065344,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000374,743824,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000375,3722136,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000376,598504,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000377,49912,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000423,503096,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000443,3670600,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000470,2871960,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000471,235872,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000472,559280,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000484,688408,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000498,7973880,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000588,220656,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000646,3296408,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000655,39296,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000662,1837040,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000681,524760,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000699,38744,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000864,1763128,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000942,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 556512 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000943,1247960,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000945,1453368,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000946,42192,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000954,128688,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000955,162880,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000956,115008,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000971,3723528,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000978,488712,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb000979,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 2512488 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001038,327904,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001055,309200,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001058,9813632,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001068,2743960,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001069,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 466488 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001070,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 3535488 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001071,20046760,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001072,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5004 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001082,5202592,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001083,2001344,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001084,2264216,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001089,1281072,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001090,1587640,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001091,156152,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001092,2306408,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001094,275856,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001102,6425768,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001103,278328,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001104,29314136,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001106,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 8560464 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001110,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5004 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001113,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5001 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001115,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 3560040 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001117,791824,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001118,3261000,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001120,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 7070976 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001122,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 7373784 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001126,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 6989136 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001128,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5003 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001132,5156144,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001133,175216,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001134,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 10025400 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001142,49528,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001144,241704,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001214,14131336,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001218,1321608,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001222,566760,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001224,22240,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001226,5070000,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001232,291160,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001242,8214792,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001245,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5004 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001248,7192944,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001251,18944928,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001260,305912,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001261,415824,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001300,24013824,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001312,2666480,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001314,12150096,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001316,12091584,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001327,19168,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001333,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 5458728 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001336,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5001 milliseconds with 417384 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001494,3018336,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001499,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5001 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001503,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 7848456 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001505,4109200,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001507,2775408,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001509,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 9297024 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001512,392136,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001514,20524224,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001518,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5003 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001520,4205240,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001522,6214504,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001524,1732024,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001528,2713584,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001530,1099192,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001532,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 4607592 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001536,5080880,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001544,3167520,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001546,29351080,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001552,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 4943136 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001553,12058256,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb001601,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5004 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb003001,1902152,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb003002,141680,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb003003,81872,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb003006,2212280,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb003008,259776,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb003010,3342048,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb003012,17467120,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb003019,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5004 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb003020,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5002 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb003021,15240392,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb003026,4566032,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100001,2034904,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100002,11331096,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100003,20346528,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100004,3360984,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100005,4485560,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100011,2501360,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100013,3529824,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100014,21183984,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100016,4490040,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100018,5981560,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100019,5313256,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100020,12521056,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100021,1875416,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100022,1903872,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100023,2752160,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100024,6694752,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100026,11799416,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100029,1826032,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100030,132168,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100031,3961152,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100033,3841168,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100034,1729800,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100035,155128,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100036,1671840,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100039,2303192,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100042,870120,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100045,1730392,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100046,947752,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100053,257696,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100054,388960,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100055,1919880,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100056,1642184,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100063,628896,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100065,3379688,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100068,3038872,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100069,1892400,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100072,5074568,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100074,9279680,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100075,9125952,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100078,501576,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100083,4669304,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100085,98480,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100088,250872,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100093,7217824,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100094,3139400,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100100,4153944,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100101,232792,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100102,10011344,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100111,911584,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100200,13703584,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100201,5714904,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100202,1489504,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100203,480024,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100204,1401512,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100205,517952,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100206,3760960,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100207,14728,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100208,306080,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100209,252176,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100210,290736,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100211,1703288,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100213,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 2684352 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100214,339864,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100215,284520,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100244,112000,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100249,16544,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100250,87216,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100362,43832,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb100381,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 7611120 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb200001,260512,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb200013,99624,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb200053,2813800,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb200054,14667280,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb200057,196864,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb300026,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5009 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb400003,19784,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb400006,96600,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb400007,378440,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb400008,504560,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gb400009,120632,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000001,18792,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000002,409152,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000003,112600,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000004,83096,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000005,1079240,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000006,888320,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000007,140048,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000008,412104,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000009,567512,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000010,336616,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000011,471008,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000012,371104,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000013,580824,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000014,164944,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000015,789648,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000016,205744,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000017,3032328,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000018,1069536,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000019,260192,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000020,858120,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000021,1285640,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000022,355248,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000023,456992,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000024,752424,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000025,52352,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000026,235368,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000027,2121960,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000028,218240,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000029,481080,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000030,1077136,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000031,1074120,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000032,950168,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000033,228016,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000034,403496,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000035,1032920,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000036,817376,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000037,265824,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000038,1869160,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000039,1089816,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000040,2076384,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000041,1135656,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000042,1070264,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000043,530856,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000044,785112,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000045,413000,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000046,1169776,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000047,465704,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000048,434384,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000049,646440,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000050,751240,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000051,278832,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000052,87848,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000053,223248,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000054,754224,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000055,535928,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000056,2854040,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000057,264040,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000058,392008,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000059,783112,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000060,158680,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000061,291184,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000062,785208,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000063,120048,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000064,147472,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000065,359688,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr000066,227032,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr003001,1034448,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr004001,25488,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100001,19672,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100002,448080,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100003,135488,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100004,91024,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100005,1239192,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100006,999328,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100007,157264,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100008,545136,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100009,702976,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100010,419432,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100011,523640,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100012,544944,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100013,723552,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100014,174840,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100015,856816,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100016,140272,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100017,3784952,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100018,1266216,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100019,353376,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100020,1080200,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100021,1625408,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100022,457880,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100023,631808,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100024,790048,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100025,52944,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100026,277480,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100027,2565936,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100028,232904,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100029,535672,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100030,1114856,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100031,1068040,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100032,897408,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100033,230272,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100034,408064,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100035,1040208,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100036,820544,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100037,267776,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100038,1913432,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100039,1098024,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100040,2522272,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100041,1270360,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100042,1162720,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100043,455800,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100044,755872,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100045,470080,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100046,1442936,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100047,525840,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100048,511968,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100050,920368,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100051,397160,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100052,93368,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100053,257680,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100054,840640,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100055,626840,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100056,3184992,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100057,293240,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100058,425760,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100059,968880,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100060,189624,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100061,396784,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100062,940816,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100063,134872,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100064,160040,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100065,427480,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr100066,285888,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,gr789365,1019672,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie000009,691080,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie000010,1512760,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie000113,4260712,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie000114,368152,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie000115,5795840,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie000116,491672,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie000117,2106160,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie000118,211152,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie000948,16536,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie000979,9348416,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie000980,1832072,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie000981,2291112,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001000,4017112,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001001,7095792,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001002,9221176,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001003,7676528,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001004,329360,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001005,850752,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001006,141368,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001007,26032,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001008,5172288,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001009,400784,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001010,533608,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001011,811696,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001012,48824,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001013,6812160,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001014,10332328,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001015,34550808,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001016,7330384,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie001017,8296680,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003001,265416,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003002,258208,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003003,639152,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003004,57912,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003005,245736,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003006,117304,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003007,106816,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003008,1003496,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003009,1663584,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003010,928616,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003011,47760,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003012,29400,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003013,214632,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003014,250912,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003015,338008,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003016,55648,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003017,156600,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003018,94328,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003019,265736,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003020,267280,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003021,371760,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003022,880848,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003023,919880,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003024,327000,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003025,1181664,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003026,53880,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003027,26096,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003028,35728,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003029,507480,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003030,132136,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003031,175376,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003032,4039704,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003033,3358024,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003034,71520,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003035,184832,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003036,53944,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003037,77944,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003038,114360,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003039,45904,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003040,191504,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003041,3497104,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003042,15888,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003043,46152,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003044,1092360,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003045,316792,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003046,679832,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003047,789392,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003048,4362904,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003049,79184,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003050,1220024,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003051,182496,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003052,27432,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003053,73760,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003054,230712,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003055,239680,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003056,105016,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003057,68816,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003058,122568,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003059,216552,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003060,246952,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003061,253768,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003062,480552,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003063,178928,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003064,174960,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003065,26128,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003066,26192,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003067,344744,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003068,15928,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003069,38984,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003070,44064,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003071,147704,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003072,92880,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003073,77240,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003074,48840,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003075,202552,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003076,217104,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003077,597112,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003078,27480,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003079,23192,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003080,71192,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003081,2493880,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003083,309448,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003084,2391000,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003085,5903816,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003086,9465376,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003087,22437264,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003088,2567888,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003089,2390640,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003090,1476640,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003091,402600,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003092,711160,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003093,755136,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003094,1967384,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie003095,532272,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie004002,1001288,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie004003,2017616,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie004004,45712,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie004005,1073744,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie004006,3106760,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie004007,26082048,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ie004008,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5008 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it000001,188824,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it003000,29847560,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it003001,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 7987584 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it003002,8576400,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it003003,6518576,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it003004,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 3969240 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it003005,1299984,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it003006,6422584,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it003007,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 8814168 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it004001,1890280,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it004002,1453384,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it004003,6267784,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it004004,1336144,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it004009,31238472,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,it004014,31167224,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,nl000046,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 1808664 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,nl000102,1309888,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,no003003,1383432,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,no003004,1070792,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,no003005,211000,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,no003011,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5000 milliseconds with 4795824 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,no003012,23306312,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pl000001,19844904,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pl004001,136128,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pl004002,165888,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt000001,114072,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt000002,112664,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt000003,246520,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt000004,107704,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt000005,38464,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt000009,127776,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt000010,25152,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt000011,89176,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt000012,2934888,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt000014,8606600,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt001002,4777440,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt001007,935368,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt003015,23165040,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt010000,1649752,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt010001,361184,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt100000,71984,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt100001,NA,Timeout was reached: [ows.emodnet-seabedhabitats.eu] Operation timed out after 5007 milliseconds with 0 bytes received,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt100002,253168,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt100003,29192,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt100004,84800,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt100005,44656,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt100006,467456,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt100007,196912,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt100008,284960,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,pt100009,794232,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,ro003102,29632,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,sp003001,22282696,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,sp003002,1529504,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,sp003003,10231472,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,sp003004,8670992,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,sp003005,12951608,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,sp003006,6117024,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,sp003007,6169584,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,sp003008,17175992,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,sp003009,23287400,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,sp003010,14193408,NA,5
+seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs,emodnet_open_maplibrary,sp003015,228936,NA,5

--- a/attic/query_layer_sizes.R
+++ b/attic/query_layer_sizes.R
@@ -1,0 +1,45 @@
+
+## QUERY Each layer of each EMODnet WFS service (for maximum amount of secs set by timeout)
+## and store layer size in bytes.
+
+## Functions ----
+get_layer_size <- function(service_url, layer_namespace, layer_name,
+                           timeout_secs = 3){
+    service_url %>%
+        httr::parse_url() %>%
+        purrr::list_merge(query = list(service = "wfs",
+                                       request = "GetFeature",
+                                       typeName = paste(layer_namespace,
+                                                        layer_name,
+                                                        sep = ":"))) %>%
+        httr::build_url() %>%
+        httr::GET(httr::timeout(timeout_secs)) %>%
+        object.size() %>%
+        as.numeric()
+}
+
+safe_get_layer_size <- purrr::safely(get_layer_size, otherwise = NA_real_)
+
+compile_layer_size_info <- function(service_url, service_name, layer_namespace,
+                                    layer_name, timeout_secs = 3){
+
+    response <- safe_get_layer_size(service_url, layer_namespace,
+                                    layer_name, timeout_secs)
+
+    tibble::tibble(service_name, service_url, layer_namespace, layer_name,
+                   layer_size_bytes = response$result,
+                   error = response$error$message, timeout_secs)
+
+}
+
+## ----------- WORKFLOW  ####
+all_layer_info <- EMODnetWFS::emodnet_get_all_wfs_info()
+
+layer_map_data <- all_layer_info %>%
+    dplyr::select(service_url, service_name, layer_namespace, layer_name) %>%
+    dplyr::mutate(timeout_secs = 5) %>%
+    # dplyr::slice(1:3) %>%
+    identity()
+
+readr::write_csv(layer_sizes, "attic/layer_sizes.csv")
+

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,1 @@
+library(httptest)

--- a/tests/testthat/test-client.R
+++ b/tests/testthat/test-client.R
@@ -1,15 +1,20 @@
-test_that("Default connection works", {
+with_mock_dir("seabed_habitats_client", {
+  test_that("Default connection works", {
     wfs <- emodnet_init_wfs_client(service = "seabed_habitats_individual_habitat_map_and_model_datasets")
-  expect_equal(class(wfs),
-               c("WFSClient", "OWSClient", "OGCAbstractObject", "R6"))
-  expect_equal(wfs$getUrl(),
-               "https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs")
+    expect_equal(class(wfs),
+                 c("WFSClient", "OWSClient", "OGCAbstractObject", "R6"))
+    expect_equal(wfs$getUrl(),
+                 "https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs")
   })
+})
 
-test_that("Specified connection works", {
+with_mock_dir("bathymetry_client", {
+  test_that("Specified connection works", {
     wfs <- emodnet_init_wfs_client(service = "bathymetry")
     expect_equal(class(wfs),
                  c("WFSClient", "OWSClient", "OGCAbstractObject", "R6"))
     expect_equal(wfs$getUrl(),
                  "https://ows.emodnet-bathymetry.eu/wfs")
+  })
 })
+

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -1,40 +1,41 @@
-wfs <- emodnet_init_wfs_client(service = "geology_seabed_substrate_maps")
 
-test_that("categorical filters work", {
+with_mock_dir("categorical_filters", {
+  test_that("categorical filters work", {
+    wfs <- emodnet_init_wfs_client(service = "geology_seabed_substrate_maps")
+    expect_equal(emodnet_get_layers(wfs = wfs,
+                                    layers = "seabed_substrate_1m",
+                                    cql_filter = "country='Baltic Sea'",
+                                    reduce_layers = TRUE)$country %>% unique(), 'Baltic Sea')
 
-  expect_equal(emodnet_get_layers(wfs = wfs,
-                                  layers = "seabed_substrate_1m",
-                                  cql_filter = "country='Baltic Sea'",
-                                  reduce_layers = TRUE)$country %>% unique(), 'Baltic Sea')
 
+    or_filter_sf <- emodnet_get_layers(wfs = wfs, layers = "seabed_substrate_1m",
+                                       cql_filter = "country='Baltic Sea' OR country='Bulgaria'",
+                                       reduce_layers = TRUE )
 
-   or_filter_sf <- emodnet_get_layers(wfs = wfs, layers = "seabed_substrate_1m",
-                       cql_filter = "country='Baltic Sea' OR country='Bulgaria'",
-                       reduce_layers = TRUE )
+    expect_equal(or_filter_sf$country %>% unique(), c("Bulgaria", "Baltic Sea"))
 
-   expect_equal(or_filter_sf$country %>% unique(), c("Bulgaria", "Baltic Sea"))
-
+  })
 })
 
-
-test_that("numeric filters work", {
-
+with_mock_dir("numeric_filters", {
+  test_that("numeric filters work", {
+    wfs <- emodnet_init_wfs_client(service = "geology_seabed_substrate_maps")
     num_filter_sf <- emodnet_get_layers(wfs = wfs, layers = "seabed_substrate_1m",
-                                       cql_filter = "country='Bulgaria' AND shape_length>1",
-                                       reduce_layers = TRUE )
+                                        cql_filter = "country='Bulgaria' AND shape_length>1",
+                                        reduce_layers = TRUE )
 
     expect_equal(num_filter_sf$country %>% unique(), c("Bulgaria"))
     expect_true(min(num_filter_sf$shape_length) > 1)
 
 
     num_filter_sf <- emodnet_get_layers(wfs = wfs, layers = "seabed_substrate_1m",
-                       cql_filter = "(country='Baltic Sea' OR country='Bulgaria') AND shape_length<1",
-                       reduce_layers = TRUE )
+                                        cql_filter = "(country='Baltic Sea' OR country='Bulgaria') AND shape_length<1",
+                                        reduce_layers = TRUE )
 
     expect_equal(num_filter_sf$country %>% unique(), c("Bulgaria", "Baltic Sea"))
     expect_true(min(num_filter_sf$shape_length) < 1)
 
+  })
+
 })
-
-
 

--- a/tests/testthat/test-info.R
+++ b/tests/testthat/test-info.R
@@ -1,46 +1,41 @@
-test_that("wfs info works from the server for a random service", {
-    service_name <- sample(emodnet_wfs$service_name, 1)
-    info <- emodnet_get_wfs_info(
-        service = service_name)
 
-    expect_s3_class(info,
-                    class = c("tbl_df", "tbl", "data.frame"))
-    expect_gt(nrow(info), 0)
-    expect_setequal(unique(info$service_name), service_name)
-})
-
-test_that("wfs all info works", {
-    skip_on_ci()
-    all_info <- emodnet_get_all_wfs_info()
-    expect_s3_class(all_info,
-                    class = c("tbl_df", "tbl", "data.frame"))
-    expect_gt(nrow(all_info), 0)
-    expect_setequal(unique(all_info$service_name), emodnet_wfs$service_name)
-})
-
-wfs_cml <- emodnet_init_wfs_client("chemistry_marine_litter")
-
-test_that("wfs info works on wfs object", {
-    layer_info_all <- emodnet_get_wfs_info(wfs_cml)
-    expect_s3_class(layer_info_all,
-                    class = c("tbl_df", "tbl", "data.frame"))
-    expect_gt(nrow(layer_info_all), 0)
-    expect_equal(unique(layer_info_all$service_name),  "chemistry_marine_litter")
-    expect_equal(unique(layer_info_all$service_url),
-                 "https://www.ifremer.fr/services/wfs/emodnet_chemistry2")
+with_mock_dir("wfs_all_info", {
+    test_that("wfs all info works", {
+        #skip_on_ci()
+        all_info <- emodnet_get_all_wfs_info()
+        expect_s3_class(all_info,
+                        class = c("tbl_df", "tbl", "data.frame"))
+        expect_gt(nrow(all_info), 0)
+        expect_setequal(unique(all_info$service_name), emodnet_wfs$service_name)
+    })
 })
 
 
-test_that("emodnet_get_layer_info works", {
-    layers <- c("sl_fishing", "sl_plasticbags")
-    layer_info_cml <-emodnet_get_layer_info(
-        wfs = wfs_cml,
-        layers = layers
-    )
-    expect_equal(nrow(layer_info_cml), 2)
-    expect_setequal(layer_info_cml$layer_name, layers)
-    expect_s3_class(layer_info_cml,
-                    class = c("tbl_df", "tbl", "data.frame"))
+with_mock_dir("wfs_info_on_wfs_object", {
+    test_that("wfs info works on wfs object", {
+        wfs_cml <- emodnet_init_wfs_client("chemistry_marine_litter")
+        layer_info_all <- emodnet_get_wfs_info(wfs_cml)
+        expect_s3_class(layer_info_all,
+                        class = c("tbl_df", "tbl", "data.frame"))
+        expect_gt(nrow(layer_info_all), 0)
+        expect_equal(unique(layer_info_all$service_name),  "chemistry_marine_litter")
+        expect_equal(unique(layer_info_all$service_url),
+                     "https://www.ifremer.fr/services/wfs/emodnet_chemistry2")
+    })
 })
 
+with_mock_dir("emodnet_get_layer_info", {
+    test_that("emodnet_get_layer_info works", {
+        wfs_cml <- emodnet_init_wfs_client("chemistry_marine_litter")
+        layers <- c("sl_fishing", "sl_plasticbags")
+        layer_info_cml <-emodnet_get_layer_info(
+            wfs = wfs_cml,
+            layers = layers
+        )
+        expect_equal(nrow(layer_info_cml), 2)
+        expect_setequal(layer_info_cml$layer_name, layers)
+        expect_s3_class(layer_info_cml,
+                        class = c("tbl_df", "tbl", "data.frame"))
+    })
+})
 

--- a/tests/testthat/test-layer_attributes.R
+++ b/tests/testthat/test-layer_attributes.R
@@ -1,62 +1,72 @@
-wfs <- suppressMessages(emodnet_init_wfs_client(service = "human_activities"))
 
-test_that("layer_attributes_get_names works", {
-    expect_equal(layer_attributes_get_names(wfs, layer = "maritimebnds"),
-                 c("objectid", "mblszotpid", "localid", "sitename", "legalfound",
-                   "legalfou_1", "country", "nationalle", "nutscode", "mblsds_mbl",
-                   "shape_leng", "the_geom"))
-    expect_equal(suppressMessages(layer_attributes_get_names(service = "human_activities", layer = "maritimebnds")),
-                 c("objectid", "mblszotpid", "localid", "sitename", "legalfound",
-                   "legalfou_1", "country", "nationalle", "nutscode", "mblsds_mbl",
-                   "shape_leng", "the_geom"))
+with_mock_dir("layer_attributes_get_names", {
+    test_that("layer_attributes_get_names works", {
+        wfs <- suppressMessages(emodnet_init_wfs_client(service = "human_activities"))
+        expect_equal(layer_attributes_get_names(wfs, layer = "maritimebnds"),
+                     c("objectid", "mblszotpid", "localid", "sitename", "legalfound",
+                       "legalfou_1", "country", "nationalle", "nutscode", "mblsds_mbl",
+                       "shape_leng", "the_geom"))
+        expect_equal(suppressMessages(layer_attributes_get_names(service = "human_activities", layer = "maritimebnds")),
+                     c("objectid", "mblszotpid", "localid", "sitename", "legalfound",
+                       "legalfou_1", "country", "nationalle", "nutscode", "mblsds_mbl",
+                       "shape_leng", "the_geom"))
+    })
 })
 
-test_that("layer_attribute_descriptions works", {
-    expect_equal(layer_attribute_descriptions(wfs, layer = "maritimebnds"),
-                 testthis::read_testdata("attr_desc"))
+with_mock_dir("layer_attribute_descriptions", {
+    test_that("layer_attribute_descriptions works", {
+        wfs <- suppressMessages(emodnet_init_wfs_client(service = "human_activities"))
+        expect_equal(layer_attribute_descriptions(wfs, layer = "maritimebnds"),
+                     testthis::read_testdata("attr_desc"))
+    })
 })
 
-test_that("layer_attribute_inspect works", {
-    sitename_insp <- layer_attribute_inspect(wfs, layer = "maritimebnds", attribute = "sitename")
-    expect_equal(class(sitename_insp),
-                 c("tabyl", "data.frame"))
-    expect_equal(names(sitename_insp),
-                 c(".", "n", "percent"))
-    expect_true(nrow(sitename_insp) > 1)
+with_mock_dir("layer_attribute_inspect", {
+    test_that("layer_attribute_inspect works", {
+        wfs <- suppressMessages(emodnet_init_wfs_client(service = "human_activities"))
+        sitename_insp <- layer_attribute_inspect(wfs, layer = "maritimebnds", attribute = "sitename")
+        expect_equal(class(sitename_insp),
+                     c("tabyl", "data.frame"))
+        expect_equal(names(sitename_insp),
+                     c(".", "n", "percent"))
+        expect_true(nrow(sitename_insp) > 1)
 
-    localid_insp <- layer_attribute_inspect(wfs, layer = "maritimebnds", attribute = "localid")
-    expect_equal(class(localid_insp),
-                 c("summaryDefault", "table"))
-    expect_equal(names(localid_insp),
-                 c("Min.", "1st Qu.", "Median", "Mean", "3rd Qu.", "Max."))
-    expect_length(localid_insp, 6L)
+        localid_insp <- layer_attribute_inspect(wfs, layer = "maritimebnds", attribute = "localid")
+        expect_equal(class(localid_insp),
+                     c("summaryDefault", "table"))
+        expect_equal(names(localid_insp),
+                     c("Min.", "1st Qu.", "Median", "Mean", "3rd Qu.", "Max."))
+        expect_length(localid_insp, 6L)
 
-})
-
-
-test_that("layer_attributes_summarise works", {
-    maritimebnds_summ <- layer_attributes_summarise(wfs, layer = "maritimebnds")
-    expect_equal("table", class(maritimebnds_summ))
-    expect_equal(maritimebnds_summ[ ,"  sitename"][2:3],
-                 structure(c("Class :character  ", "Mode  :character  "), .Names = c("",
-                                                                                     "")))
-    expect_equal(maritimebnds_summ[ ,"  shape_leng"][1],
-                 structure("Min.   :   0.0000  ", .Names = ""))
-    expect_equal(maritimebnds_summ[ ,"   objectid"][1],
-                 structure("Min.   :   1.0  ", .Names = ""))
-    expect_equal(ncol(maritimebnds_summ),
-                 length(layer_attributes_get_names(wfs, layer = "maritimebnds")))
+    })
 })
 
 
-test_that("get_default_crs works", {
-    #expect_equal(get_layer_default_crs(layer = "maritimebnds", wfs, output = "crs"),
-       #          testthis::read_testdata("maritime_crs"))
-    expect_equal(get_layer_default_crs(layer = "maritimebnds", wfs, output = "epsg.text"),
-                 "epsg:4326")
-    expect_equal(get_layer_default_crs(layer = "maritimebnds", wfs, output = "epsg.num"),
-                 4326)
+with_mock_dir("layer_attributes_summarise", {
+    test_that("layer_attributes_summarise works", {
+        wfs <- suppressMessages(emodnet_init_wfs_client(service = "human_activities"))
+        maritimebnds_summ <- layer_attributes_summarise(wfs, layer = "maritimebnds")
+        expect_equal("table", class(maritimebnds_summ))
+        expect_equal(maritimebnds_summ[ ,"  sitename"][2:3],
+                     structure(c("Class :character  ", "Mode  :character  "), .Names = c("",
+                                                                                         "")))
+        expect_equal(maritimebnds_summ[ ,"  shape_leng"][1],
+                     structure("Min.   :   0.0000  ", .Names = ""))
+        expect_equal(maritimebnds_summ[ ,"   objectid"][1],
+                     structure("Min.   :   1.0  ", .Names = ""))
+        expect_equal(ncol(maritimebnds_summ),
+                     length(layer_attributes_get_names(wfs, layer = "maritimebnds")))
+    })
 })
 
+with_mock_dir("get_default_crs", {
+    test_that("get_default_crs works", {
+        wfs <- suppressMessages(emodnet_init_wfs_client(service = "human_activities"))
+        expect_equal(get_layer_default_crs(layer = "maritimebnds", wfs, output = "epsg.text"),
+                     "epsg:4326")
+        expect_equal(get_layer_default_crs(layer = "maritimebnds", wfs, output = "epsg.num"),
+                     4326)
+    })
 
+})
 

--- a/tests/testthat/test-layers.R
+++ b/tests/testthat/test-layers.R
@@ -1,89 +1,93 @@
-test_that("get layers works on server", {
-  l_data <- emodnet_get_layers(service = "seabed_habitats_individual_habitat_map_and_model_datasets",
-                               layers = c("dk003069", "dk003070"))
-  l_crs <- purrr::map_int(l_data, ~sf::st_crs(.x)$epsg) %>% unique()
+with_mock_dir("get_layers_direct", {
+  test_that("get layers works on server", {
+    l_data <- emodnet_get_layers(service = "seabed_habitats_individual_habitat_map_and_model_datasets",
+                                 layers = c("dk003069", "dk003070"))
+    l_crs <- purrr::map_int(l_data, ~sf::st_crs(.x)$epsg) %>% unique()
 
-  expect_length(l_crs, 1)
-  expect_equal(3857, l_crs)
-  expect_equal(length(l_data), 2)
-  expect_type(l_data, "list")
-  expect_s3_class(l_data[[1]], class = c("sf", "data.frame"))
-  expect_s3_class(l_data[[2]], class = c("sf", "data.frame"))
-  expect_gt(nrow(l_data[[1]]), 0)
-  expect_gt(nrow(l_data[[2]]), 0)
+    expect_length(l_crs, 1)
+    expect_equal(3857, l_crs)
+    expect_equal(length(l_data), 2)
+    expect_type(l_data, "list")
+    expect_s3_class(l_data[[1]], class = c("sf", "data.frame"))
+    expect_s3_class(l_data[[2]], class = c("sf", "data.frame"))
+    expect_gt(nrow(l_data[[1]]), 0)
+    expect_gt(nrow(l_data[[2]]), 0)
 
+  })
+})
+with_mock_dir("crs_trasform_direct", {
+  test_that("crs trasform works from server", {
+    l_data <- emodnet_get_layers(service = "seabed_habitats_individual_habitat_map_and_model_datasets",
+                                 layers = "dk003070", crs = 4326)
+    l_crs <- purrr::map_int(l_data, ~sf::st_crs(.x)$epsg) %>% unique()
+    expect_length(l_crs, 1)
+    expect_equal(4326, l_crs)
+  })
 })
 
-test_that("crs trasform works from server", {
-  l_data <- emodnet_get_layers(service = "seabed_habitats_individual_habitat_map_and_model_datasets",
-                               layers = "dk003070", crs = 4326)
-  l_crs <- purrr::map_int(l_data, ~sf::st_crs(.x)$epsg) %>% unique()
-  expect_length(l_crs, 1)
-  expect_equal(4326, l_crs)
+with_mock_dir("get_layers_wfs", {
+  test_that("get layers works on wfs object", {
+    wfs_cml <- emodnet_init_wfs_client("chemistry_marine_litter")
+    layers <- c("sl_fishing", "sl_plasticbags")
+
+    l_data <- emodnet_get_layers(wfs = wfs_cml, layers = layers)
+    l_crs <- purrr::map_int(l_data, ~sf::st_crs(.x)$epsg) %>% unique()
+
+    expect_length(l_crs, 1)
+    expect_equal(4326, l_crs)
+    expect_equal(length(l_data), 2)
+    expect_type(l_data, "list")
+    expect_s3_class(l_data[[1]], class = c("sf", "data.frame"))
+    expect_s3_class(l_data[[2]], class = c("sf", "data.frame"))
+    expect_gt(nrow(l_data[[1]]), 0)
+    expect_gt(nrow(l_data[[2]]), 0)
+  })
+})
+with_mock_dir("crs_trasform_wfs", {
+  test_that("crs trasform works from wfs object", {
+    wfs_cml <- emodnet_init_wfs_client("chemistry_marine_litter")
+    layers <- c("sl_fishing", "sl_plasticbags")
+
+    l_data <- emodnet_get_layers(wfs = wfs_cml, layers = layers, crs = 3857)
+    l_crs <- purrr::map_int(l_data, ~sf::st_crs(.x)$epsg) %>% unique()
+    expect_length(l_crs, 1)
+    expect_equal(3857, l_crs)
+  })
+})
+with_mock_dir("get_layer_correct_crs", {
+  test_that("crs checking from wfs service works correctly", {
+    l_data <- emodnet_get_layers(service="geology_seabed_substrate_maps",
+                                 layers = "seabed_substrate_1m",
+                                 cql_filter = "country='Baltic Sea'")
+
+    expect_equal(sf::st_crs(l_data[[1]])$input, "+init=epsg:3034")
+  })
 })
 
-
-
-wfs_cml <- emodnet_init_wfs_client("chemistry_marine_litter")
-layers <- c("sl_fishing", "sl_plasticbags")
-
-test_that("get layers works on wfs object", {
-  l_data <- emodnet_get_layers(wfs = wfs_cml, layers = layers)
-  l_crs <- purrr::map_int(l_data, ~sf::st_crs(.x)$epsg) %>% unique()
-
-  expect_length(l_crs, 1)
-  expect_equal(4326, l_crs)
-  expect_equal(length(l_data), 2)
-  expect_type(l_data, "list")
-  expect_s3_class(l_data[[1]], class = c("sf", "data.frame"))
-  expect_s3_class(l_data[[2]], class = c("sf", "data.frame"))
-  expect_gt(nrow(l_data[[1]]), 0)
-  expect_gt(nrow(l_data[[2]]), 0)
+with_mock_dir("random_layer_fail", {
+  test_that("random layers fail", {
+    expect_error(emodnet_get_layers(layers = c("randomlayer")))
+  })
 })
-
-test_that("crs trasform works from wfs object", {
-  l_data <- emodnet_get_layers(wfs = wfs_cml, layers = layers, crs = 3857)
-  l_crs <- purrr::map_int(l_data, ~sf::st_crs(.x)$epsg) %>% unique()
-  expect_length(l_crs, 1)
-  expect_equal(3857, l_crs)
-})
-
-test_that("crs checking from wfs service works correctly", {
-  l_data <- emodnet_get_layers(service="geology_seabed_substrate_maps",
-                               layers = "seabed_substrate_1m",
-                               cql_filter = "country='Baltic Sea'")
-
-  expect_equal(sf::st_crs(l_data[[1]])$input, "+init=epsg:3034")
-})
-
-
-test_that("reduce layers on single layer returns sf", {
-  sf_data <- emodnet_get_layers(service="geology_seabed_substrate_maps",
-                               layers = "seabed_substrate_1m",
-                               cql_filter = "country='Baltic Sea'",
-                               reduce_layers = TRUE)
-
-  expect_s3_class(sf_data, c("sf", "data.frame"))
-})
-
-test_that("random layers fail", {
-  expect_error(emodnet_get_layers(layers = c("randomlayer")))
-})
-
-test_that("reduce works", {
+with_mock_dir("reduce", {
+  test_that("reduce works", {
     sf_data <- emodnet_get_layers(
       service = "seabed_habitats_individual_habitat_map_and_model_datasets",
-        layers = c("dk003069", "dk003070"),
-        reduce_layers = TRUE)
+      layers = c("dk003069", "dk003070"),
+      reduce_layers = TRUE)
     expect_s3_class(sf_data, class = c("sf", "data.frame"))
     expect_gt(nrow(sf_data), 0)
+  })
 })
 
-#test_that("Failing layers handled correctly", {
-#        expect_warning(emodnet_get_layers(layers = "be000071"))
-#    expect_null(suppressWarnings(emodnet_get_layers(
-#        layers = "be000071"))[[1]])
-#})
+with_mock_dir("reduce_single_layer", {
+  test_that("reduce layers on single layer returns sf", {
+    sf_data <- emodnet_get_layers(service="geology_seabed_substrate_maps",
+                                  layers = "seabed_substrate_1m",
+                                  cql_filter = "country='Baltic Sea'",
+                                  reduce_layers = TRUE)
 
-
+    expect_s3_class(sf_data, c("sf", "data.frame"))
+  })
+})
 

--- a/tests/testthat/test-layers.R
+++ b/tests/testthat/test-layers.R
@@ -60,7 +60,7 @@ with_mock_dir("get_layer_correct_crs", {
                                  layers = "seabed_substrate_1m",
                                  cql_filter = "country='Baltic Sea'")
 
-    expect_equal(sf::st_crs(l_data[[1]])$input, "+init=epsg:3034")
+    expect_equal(sf::st_crs(l_data[[1]])$input, "epsg:3034")
   })
 })
 

--- a/vignettes/emodnetwfs.Rmd
+++ b/vignettes/emodnetwfs.Rmd
@@ -11,6 +11,10 @@ vignette: >
 knitr::opts_chunk$set(echo = TRUE, eval = TRUE, warning = FALSE, collapse = TRUE, comment = "#>")
 ```
 
+```{r, include=FALSE}
+library(httptest)
+start_vignette("emodnetwfs-case-study")
+```
 
 ## Introduction
 
@@ -168,3 +172,8 @@ Tim Appelhans, Florian Detsch, Christoph Reudenbach and Stefan Woellauer (2020).
 Please cite this package as: 
 
 Anna Krystalli (2020). EMODnetWFS: Access EMODnet Web Feature Service data through R. R package version 0.0.2. https://github.com/EMODnet/EMODnetWFS. Integrated data products created under the European Marine Observation Data Network (EMODnet) Biology project (EASME/EMFF/2017/1.3.1.2/02/SI2.789013), funded by the by the European Union under Regulation (EU) No 508/2014 of the European Parliament and of the Council of 15 May 2014 on the European Maritime and Fisheries Fund.
+
+```{r, include=FALSE}
+end_vignette()
+```
+

--- a/vignettes/eqcl_filtering.Rmd
+++ b/vignettes/eqcl_filtering.Rmd
@@ -14,6 +14,10 @@ knitr::opts_chunk$set(
 )
 ```
 
+```{r, include=FALSE}
+library(httptest)
+start_vignette("ecql_filtering")
+```
 
 So far, we've demonstrated using `EMODnetWFS` to request complete layers.
 
@@ -35,7 +39,7 @@ The examples provided here are only a small subset of filtering functionality av
 
 - [ECQL Reference](https://docs.geoserver.org/latest/en/user/filter/ecql_reference.html): reference for the syntax of the ECQL language
 
-- [Filter Function Reference](https://docs.geoserver.org/stable/en/user/filter/function_reference.html): The OGC Filter Encoding specification provides a generic concept of a filter function. A filter function is a named function with any number of arguments, which can be used in a filter expression to perform specific calculations. This provides much richer expressiveness for defining filters.GeoServer provides many different kinds of filter functions, covering a wide range of functionality including mathematics, string formatting, and geometric operations
+- [Filter Function Reference](https://docs.geoserver.org/stable/en/user/filter/function_reference.html): The OGC Filter Encoding specification provides a generic concept of a filter function. A filter function is a named function with any number of arguments, which can be used in a filter expression to perform specific calculations. This provides much richer expressiveness for defining filters. GeoServer provides many different kinds of filter functions, covering a wide range of functionality including mathematics, string formatting, and geometric operations
 
 - [CQL and ECQL Tutorial](https://docs.geoserver.org/stable/en/user/tutorials/cql/cql_tutorial.html) shows examples of defining filters.
 
@@ -308,3 +312,7 @@ unique(filter_sf3$country)
 There is more that can accomplished by using the EMODnet WFS services than downloading data. The EMODnetWFS package is built on top of the [ows4R](https://github.com/eblondel/ows4R) library, meaning that all the functionalities of this package are available for EMODnetWFS. The ows4R returns a special type of R object called R6. You can learn more in Hadley Wickham's chapter on R6 Objects of the [Advance R book](https://adv-r.hadley.nz/r6.html).
 
 For instance: it is not efficient to read a large dataset into R just and later subset part of it. This requires longer waiting times and more bandwidth usage, and in very large datasets it would simply not be possible. For instance, all the occurrences data available through the EMODnet Biology portal are stored in [one table](https://www.emodnet-biology.eu/emodnet-data-format): These are approximately 30 millions rows! In this case, we suggest you access the EMODnet Biology occurrence data through the [download toolbox](https://www.emodnet-biology.eu/toolbox/) or the [eurobis R package](https://github.com/lifewatch/eurobis/) instead.
+
+```{r, include=FALSE}
+end_vignette()
+```


### PR DESCRIPTION

I’ve been going round in circles on my own but haven’t shared this so
far because of issues with the approach (i.e. the size of the cached
data, see below), but I realised that if I just share the alterations to
the code, it obviously won’t work on GitHub Actions but others could at
least pull the branch and experiment locally to give feedback.

So decided to try and write up the issues I’ve been coming up against,
some steps and proposed solutions so far and try and get some feedback
from you!

The PR relates to \#26 and describes using `httptest` to cache tests &
vignette queries & problems so far:

## Using `httptest`

### Approach:

#### Tests

Wrap functions in `with_mock_dir`. Provide a unique folder name that
will be used or created under `tests/testthat/`

#### Vignettes

Use `start_vignette()` at the start of any vignette to either use
previously recorded responses, if they exist, or capture real responses
for future use. Use `end_vignette()` at the end.

### Result:

http request responses for tests are cached in named folder in
`tests/testthat/` whereas for vignettes in the `vignettes/` folder.

### Issues

-   [ ] **1. Path to created files too long** triggering an error during
    checks regarding “non-portable file paths”. Need to add a request
    preprocessing function as described in the
    [faq](https://enpiar.com/r/httptest/index.html#how-do-i-fix-non-portable-file-paths)
    vignette, e.g.

    ``` r
    set_requester(function (request) {
    gsub_request(request, "https\\://language.googleapis.com/v1/", "api/")
    })
    ```

-   [ ] **2. Size of files can be too large** and add significantly to
    the size of the repo. Currently the `tests/testthat/` folder size is
    37.8 MB whereas the vignettes folder is a whopping 1.5 GB!!. To run
    tests using the framework using GitHub Actions though, all these
    files would need to be commmited to git! For this reason, although
    I’ve committed the code alterations I’ve made to incorporate
    `httptest`, I am ignoring the actual cached data folders for the
    time being until a solution is decided.

-   [ ] **3. Don’t work outside the box for wfs!** According to docs,
    once the tests are first run, they should then run successfully the
    next time they are run, even without an internet connection.
    However, when run with internet, some tests appear to fail or throw
    warnings (but not all).

    ``` r
    ℹ Testing EMODnetWFS
    ✓ | F W S  OK | Context
    ✓ |         4 | client [1.7s]                                               
    ✓ |   4     6 | filter [0.6s] 
    ✓ |        10 | info [2.8s]                                                 
    x | 1 3    11 | layer_attributes [4.1s] 
    x | 1 11   24 | layers [9.2s] 

    ══ Results ════════════════════════════════════════════════════════════════════════
    Duration: 18.4 s

    [ FAIL 2 | WARN 18 | SKIP 0 | PASS 55 ]
    Warning message:
    In XML::xmlParse(xsdFile, isSchema = TRUE, xinclude = TRUE, error = function(msg,  :
      NULL value for external reference
    ```

    -   **WARNINGS:**
        -   **categorical filters work**

            ``` r
            with_mock_dir("categorical_filters", {
            test_that("categorical filters work", {
              wfs <- emodnet_init_wfs_client(service = "geology_seabed_substrate_maps")
              expect_equal(emodnet_get_layers(wfs = wfs,
                                              layers = "seabed_substrate_1m",
                                              cql_filter = "country='Baltic Sea'",
                                              reduce_layers = TRUE)$country %>% unique(), 'Baltic Sea')


              or_filter_sf <- emodnet_get_layers(wfs = wfs, layers = "seabed_substrate_1m",
                                                 cql_filter = "country='Baltic Sea' OR country='Bulgaria'",
                                                 reduce_layers = TRUE )

              expect_equal(or_filter_sf$country %>% unique(), c("Bulgaria", "Baltic Sea"))

            })
              })
            ```

            **Warning during test run:**

                Warning (test-filter.R:5:5): categorical filters work
                GDAL Error 1: Could not resolve host: drive.emodnet-geology.eu
                Backtrace:
                  1. testthat::expect_equal(...) test-filter.R:5:4
                  6. EMODnetWFS::emodnet_get_layers(...)
                  9. purrr::map2(...)
                 10. EMODnetWFS:::.f(.x[[1L]], .y[[1L]], ...)
                 11. EMODnetWFS::ews_get_layer(.x, wfs, cql_filter = .y)
                 19. wfs$getFeatures(x, cql_filter = utils::URLencode(cql_filter))
                 20. ft$getFeatures(...)
                 22. sf:::st_read.character(destfile, quiet = TRUE)
                 23. sf:::CPL_read_ogr(...)
    -   **ERROR:**
        -   **layer\_attributes\_summarise works**

            ``` r
            with_mock_dir("layer_attributes_summarise", {
            test_that("layer_attributes_summarise works", {
                wfs <- suppressMessages(emodnet_init_wfs_client(service = "human_activities"))
                maritimebnds_summ <- layer_attributes_summarise(wfs, layer = "maritimebnds")
                expect_equal("table", class(maritimebnds_summ))
                expect_equal(maritimebnds_summ[ ,"  sitename"][2:3],
                             structure(c("Class :character  ", "Mode  :character  "), .Names = c("",
                                                                                                 "")))
                expect_equal(maritimebnds_summ[ ,"  shape_leng"][1],
                             structure("Min.   :   0.0000  ", .Names = ""))
                expect_equal(maritimebnds_summ[ ,"   objectid"][1],
                             structure("Min.   :   1.0  ", .Names = ""))
                expect_equal(ncol(maritimebnds_summ),
                             length(layer_attributes_get_names(wfs, layer = "maritimebnds")))
            })
            })
            ```

            -   **Error message during tests:**

            <!-- -->

                Error (test-layer_attributes.R:48:9): layer_attributes_summarise works
                Error in `sf::st_drop_geometry(.)`: st_drop_geometry only works with objects of class sf
                Backtrace:
                 1. EMODnetWFS::layer_attributes_summarise(wfs, layer = "maritimebnds") test-layer_attributes.R:48:8
                 6. sf::st_drop_geometry(.)

## Solutions \[WIP\]

1.  [ ] Follow instructions to implement appropriate `set_requester`
    function (will tackle last.

2.  [ ] One option to tackle the size of cached data is to refactor our
    tests and vignettes (vignettes especially) to request smaller
    layers. To that effect, I wrote a short script to query each layer
    of each service (but time out and return `NA` after 5 secs for
    efficiency) and return the size of each layer. You can find both
    [script](/attic/query_layer_sizes.R) & [result
    csv](/attic/layer_sizes.csv) in the `attic/` dir. Using that info,
    we can focus on the smaller layers in our examples, tests and
    vignettes.

From a similar question in the rOpenSci slack (where this super useful
resource was shared: 😉
<https://blog.r-hub.io/2020/05/29/distribute-data/#data-outside-of-your-packag>
), a suggestion was to store large cached data externally from the
package repo and pull it in during testing. That obviously requires
internet and effort to implement as not only do we need the data but we
also need a mechanism for periodically updating the cached data. Setting
this up, at first thought, feels like it would require duplication of
code somewhere else, introducing the need for keeping two copies of it
synced, so would need some thought as how to do this successfully.

3.  [ ] Still trouble shooting this and whether `httptest` is the right
    way to go. It feels like most of the warnings / errors generated
    with no internet are the result of the interaction of the `sf`
    package with the requests once they are received. Indeed most of the
    tests throw warnings, not actual errors so they actually pass.

When there IS and internet connection (which there will always be on
GitHub Actions), they actually all pass and quicker than on `master` so
I’m assuming the cached data is being used with some differences in time
where the cached response needs to be processed to `sf` during test
runtime.

Testing on `http-tests` with cache & internet (2 fewer tests):

    ℹ Testing EMODnetWFS
    ✓ | F W S  OK | Context
    ✓ |         4 | client [1.6s]                                     
    ✓ |         6 | filter [1.2s]                                     
    ✓ |        10 | info [2.9s]                                       
    ✓ |        16 | layer_attributes [3.8s]                           
    ✓ |        25 | layers [10.3s]                                    

    ══ Results ═══════════════════════════════════════════════════════
    Duration: 19.7 s

Testing on `master` without cache (test fail because of chance in crs
definition on server corrected in this PR:

    ℹ Testing EMODnetWFS
    ✓ | F W S  OK | Context
    ✓ |         4 | client [2.0s]                                     
    ✓ |         6 | filter [2.9s]                                     
    ✓ |        13 | info [6.3s]                                       
    ✓ |        16 | layer_attributes [2.1s]                           
    x | 1      24 | layers [13.8s]   

    Duration: 27.1 s

So not sure how much of a problem this is. It’s just a bit
unsatisfactory as technically these should now work without internet.

------------------------------------------------------------------------

Overall just wanted to update you and make the issues a bit more visible
and see if anyone had any feedback or suggestions.
