### PR TITLE
Fix R-CMD-CHECK workflow ubuntu issues

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -93,7 +93,8 @@ jobs:
             libudunits2-dev \
             libgdal-dev \
             libgeos-dev \
-            libproj-dev
+            libproj-dev \
+            libsodium-dev
 
       - name: Install dependencies Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -89,7 +89,7 @@ jobs:
           # install spatial dependencies
           # sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
           # sudo apt update
-          sudo apt install \
+          sudo apt-get install \
             libudunits2-dev \
             libgdal-dev \
             libgeos-dev \

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -94,7 +94,8 @@ jobs:
             libgdal-dev \
             libgeos-dev \
             libproj-dev \
-            libsodium-dev
+            libsodium-dev \
+            libcurl4-openssl-dev
 
       - name: Install dependencies Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -87,8 +87,8 @@ jobs:
           sudo -s eval "$sysreqs"
 
           # install spatial dependencies
-          sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
-          sudo apt update
+          # sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
+          # sudo apt update
           sudo apt install \
             libudunits2-dev \
             libgdal-dev \


### PR DESCRIPTION
Looking into the failures in the ubuntu runs on the **R-CMD-CHECK** workflow. In the end, it's probably not an issue with sf itself but changes in the testing environment when moving to 20.04. The errors during sf install point to it potentially being a problem with configurations arising from multiple versions of proj. 

Experimenting with whether the `update` command might be causing multiple copies. 

The **test-services** workflow was **not in fact failing  on `sf` installation** which was successful, and the only Linux configuration details I can see between the two setups I can see is that **test-services** did not include an update step.

Instead, **test-services** was failing on the installation of `ows4r` because of error in installation of `sodium` (see https://github.com/EMODnet/EMODnetWFS/runs/5045539315?check_suite_focus=true#step:6:2764)  

```
* installing *source* package ‘sodium’ ...
** package ‘sodium’ successfully unpacked and MD5 sums checked
** using staged installation
Package libsodium was not found in the pkg-config search path.
Perhaps you should add the directory containing `libsodium.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libsodium' found
Using PKG_CFLAGS=
Using PKG_LIBS=-lsodium
--------------------------- [ANTICONF] --------------------------------
Configuration failed because libsodium was not found. Try installing:
 * deb: libsodium-dev (Debian, Ubuntu, etc)
 * rpm: libsodium-devel (Fedora, EPEL)
 * csw: libsodium_dev (Solaris)
 * brew: libsodium (OSX)
If libsodium is already installed, check that 'pkg-config' is in your
PATH and PKG_CONFIG_PATH contains a libsodium.pc file. If pkg-config
is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:
R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'
-------------------------- [ERROR MESSAGE] ---------------------------
<stdin>:1:10: fatal error: sodium.h: No such file or directory
compilation terminated.
--------------------------------------------------------------------
ERROR: configuration failed for package ‘sodium’
* removing ‘/home/runner/work/_temp/Library/sodium’
```
which leads to a cascade of missing packages affecting `ows4r` https://github.com/EMODnet/EMODnetWFS/runs/5045539315?check_suite_focus=true#step:6:4853

```
Warning messages:
1: In i.p(...) : installation of package ‘sodium’ had non-zero exit status
2: In i.p(...) :
  installation of package ‘keyring’ had non-zero exit status
3: In i.p(...) :
  installation of package ‘geometa’ had non-zero exit status
4: In i.p(...) : installation of package ‘ows4R’ had non-zero exit status
```

Looks like the issue started through adding `keyring` as a `geometa` dependency in https://github.com/eblondel/geometa/blob/d22371e78a1367174c4437d7f9915e66cc332346/DESCRIPTION, 12 days ago, which is roughly when the errors started appearing in Test-Services.

In any case, I've added `libsodium-dev` as a system dependency for Linux.

Will now test to see whether the not updating solves gdal and proj configuration issues. 🤞