### PR TITLE
fix: refactor guess_layer_format() for more robustness

### DIFF
--- a/R/info.R
+++ b/R/info.R
@@ -114,7 +114,7 @@ get_abstract_null <- function(x) {
 }
 
 guess_layer_format <- function(layer) {
-  if (any(layer$getDescription(pretty = TRUE)[["geometry"]])) {
+  if (!is.null(layer$getGeometryType())) {
     "sf"
   } else {
     "data.frame"


### PR DESCRIPTION
Fix #158
Fix #157 

@salvafern could you please have a look?

``` r
wfs <- EMODnetWFS::emodnet_init_wfs_client(service = "physics")
#> Loading ISO 19139 XML schemas...
#> Loading ISO 19115 codelists...
#> ✔ WFS client created successfully
#> ℹ Service: "https://prod-geoserver.emodnet-physics.eu/geoserver/ows"
#> ℹ Version: "2.0.0"
str(EMODnetWFS::emodnet_get_layer_info(wfs, layers = "EP_PLATFORMS_MO_ATLAS"))
#> rowws_df [1 × 9] (S3: rowwise_df/tbl_df/tbl/data.frame)
#>  $ data_source    : chr "emodnet_wfs"
#>  $ service_name   : chr "https://prod-geoserver.emodnet-physics.eu/geoserver/ows"
#>  $ service_url    : chr "physics"
#>  $ layer_name     : chr "EP_PLATFORMS_MO_ATLAS"
#>  $ title          : chr "EMODnet Physics - Moorings - ATLAS"
#>  $ abstract       : chr "EMODnet Physics DB of the mooring. Global collection. \r\nA mooring in oceanography is a collection of devices,"| __truncated__
#>  $ class          : chr "WFSFeatureType"
#>  $ format         : chr "data.frame"
#>  $ layer_namespace: chr "EMODnet"
#>  - attr(*, "groups")= tibble [1 × 1] (S3: tbl_df/tbl/data.frame)
#>   ..$ .rows: list<int> [1:1] 
#>   .. ..$ : int 1
#>   .. ..@ ptype: int(0)
```

<sup>Created on 2024-02-28 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>